### PR TITLE
[SB] Discover plugins at AdJS.Plugins on Client

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -47,22 +47,22 @@
       <img src="http://www.econify.com/assets/econify_logo.png">
       <small>Copyright &copy; 2018 Econify, LLC. All Rights Reserved.</small>
     </div>
-    <script type="text/javascript" src="http://localhost:8081/adjs.main.js"></script>
-    <script type="text/javascript" src="http://localhost:8081/adjs.networks.dfp.js"></script>
-    <script type="text/javascript" src="http://localhost:8081/adjs.plugins.log.js"></script>
-    <script type="text/javascript" src="http://localhost:8081/adjs.plugins.autorender.js"></script>
-    <script type="text/javascript" src="http://localhost:8081/adjs.plugins.debug.js"></script>
-    <script type="text/javascript" src="http://localhost:8081/adjs.plugins.sticky.js"></script>
-    <script type="text/javascript" src="http://localhost:8081/adjs.plugins.autorefresh.js"></script>
+    <script type="text/javascript" src="http://localhost:8081/adjs.core.min.js"></script>
+    <script type="text/javascript" src="http://localhost:8081/adjs.Networks.DFP.min.js"></script>
+    <script type="text/javascript" src="http://localhost:8081/adjs.Plugins.Logging.min.js"></script>
+    <script type="text/javascript" src="http://localhost:8081/adjs.Plugins.AutoRender.min.js"></script>
+    <script type="text/javascript" src="http://localhost:8081/adjs.Plugins.Debug.min.js"></script>
+    <script type="text/javascript" src="http://localhost:8081/adjs.Plugins.Sticky.min.js"></script>
+    <script type="text/javascript" src="http://localhost:8081/adjs.Plugins.AutoRefresh.min.js"></script>
     <script type="text/javascript">
       // import. (manipulated)
-      const mainPage = new AdJS.Bucket(DFPNetwork, {
+      const mainPage = new AdJS.Bucket(AdJS.Networks.DFP, {
         plugins: [
-          LoggingPlugin,
-          AutoRenderPlugin,
-          AutoRefreshPlugin,
-          DebugPlugin,
-          StickyPlugin,
+          AdJS.Plugins.Logging,
+          AdJS.Plugins.AutoRender,
+          AdJS.Plugins.AutoRefresh,
+          AdJS.Plugins.Debug,
+          AdJS.Plugins.Sticky,
         ],
         defaults: {
           refreshRateInSeconds: 10,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10452,6 +10452,12 @@
         "crypto-random-string": "^1.0.0"
       }
     },
+    "unminified-webpack-plugin": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unminified-webpack-plugin/-/unminified-webpack-plugin-2.0.0.tgz",
+      "integrity": "sha512-Um2Yw2OfAhRuIXC9G3CDlR2Df1TkYRihwS4QEuQs5qe/nq+l1OEH+Getq9OjHspqtjR+e09m7rUQWi5fNfYj4g==",
+      "dev": true
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "ts-loader": "^4.4.2",
     "tslint": "^5.11.0",
     "typescript": "^3.4.5",
+    "unminified-webpack-plugin": "^2.0.0",
     "webpack": "^4.30.0",
     "webpack-cli": "^3.3.2",
     "webpack-dev-server": "^3.3.1"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,105 @@
+import { ILoadedModulesCache, LoadedModules } from './types';
+
 import Bucket from './Bucket';
+import isServer from './utils/isServer';
+
+const LOADED_MODULES: ILoadedModulesCache = {
+  Plugins: {},
+  Networks: {},
+  Vendors: {},
+};
+
+const _ADJS: ILoadedModulesCache = isServer() ? LOADED_MODULES : window._ADJS = window._ADJS || LOADED_MODULES;
+
+_ADJS.Plugins = _ADJS.Plugins || LOADED_MODULES.Plugins;
+_ADJS.Vendors = _ADJS.Vendors || LOADED_MODULES.Vendors;
+_ADJS.Networks = _ADJS.Networks || LOADED_MODULES.Networks;
+
+const PluginsHandler = {
+  get(plugins: LoadedModules, property: string | symbol): any {
+    const cleanedProperty: string = String(property);
+
+    if (isServer()) {
+      if (typeof property === 'symbol') {
+        return {};
+      }
+
+      throw new Error(`
+        Using the Networks or Plugins property on AdJS is only available when installing via script.
+        If you are compiling the AdJS library locally within your project, use require to
+        specify the plugin directly.
+
+        Example:
+          import DFP from 'adjs/networks/DFP';
+          import AutoRender from 'adjs/plugins/AutoRender';
+
+          new AdJS.Bucket(DFP, {
+            plugins: [
+              AutoRender,
+            ],
+          });
+      `);
+    }
+
+    if (!plugins[cleanedProperty]) {
+      throw new Error(`
+        The ${cleanedProperty} Plugin or Network has not been included in your bundle. Please
+        manually include the script tag associated with this plugin or network. You can see
+        documentation on https://adjs.dev.
+
+        Example:
+          <script src="https://cdn.adjs.dev/core.min.js"></script>
+          <script src="https://cdn.adjs.dev/DFP.min.js"></script>
+          <script src="https://cdn.adjs.dev/AutoRender.min.js"></script>
+
+          <script>
+            new AdJS.Bucket(AdJS.Networks.DFP, {
+              plugins: [
+                AdJS.Plugins.AutoRender,
+              ],
+            });
+          </script>
+      `);
+    }
+
+    return plugins[cleanedProperty];
+  },
+};
+
+const Plugins = new Proxy(_ADJS.Plugins, PluginsHandler);
+const Networks = new Proxy(_ADJS.Networks, PluginsHandler);
+const Vendors = new Proxy(_ADJS.Vendors, PluginsHandler);
 
 const AdJS = {
-  activeCorrelatorId: null,
   Bucket,
+
+  Plugins,
+  Networks,
+  Vendors,
+
+  activeCorrelatorId: null,
 };
 
 /*
-if (typeof window !== 'undefined') {
-  window.adjsCmd = window.adjsCmd || [];
+ * TODO:
+ *  Allow a user to queue up commands before
+ *  AdJS has loaded
+ *
+ * Example:
 
-  window.adjsCmd.forEach((fn) => {
-    fn();
-  });
+  if (!isServer()) {
+    AdJS.cmd = window._AdJS.cmd || [];
 
-  window.adjsCmd.push = (fn) => {
-    fn();
+    AdJS.cmd.forEach((fn) => {
+      fn();
+    });
+
+    AdJS.cmd = [];
+
+    AdJS.cmd.push = (fn) => {
+      fn();
+    }
   }
-}
 */
 
 export default AdJS;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,19 @@
+declare global {
+  // tslint:disable-next-line
+  interface Window {
+    _ADJS: ILoadedModulesCache;
+  }
+}
+
 export type Maybe<T> = T | void;
+
+export type LoadedModules = any;
+
+export interface ILoadedModulesCache {
+  Plugins: LoadedModules;
+  Networks: LoadedModules;
+  Vendors: LoadedModules;
+}
 
 export interface IEventType {
   [key: string]: string;


### PR DESCRIPTION
If a user loads adjs plugins via script tags they will automatically register themselves via `AdJS.Plugins` (i.e. `AdJS.Plugins.AutoRender`).

On the server it will error and request they import the package directly.