### PR TITLE
Default confines for unspecified breakpoints

### DIFF
--- a/src/plugins/Responsive.ts
+++ b/src/plugins/Responsive.ts
@@ -55,11 +55,11 @@ class ResponsivePlugin extends GenericPlugin {
         breakpointSpecifiedForViewWidth = true;
         this.currentConfines = { from, to };
       }
-
-      if (!breakpointSpecifiedForViewWidth) {
-        this.currentConfines = {};
-      }
     });
+
+    if (!breakpointSpecifiedForViewWidth) {
+      this.currentConfines = {};
+    }
   }
 
   public isRefreshDisabled() {


### PR DESCRIPTION
I think this might have happened in a merge conflict resolution