### PR TITLE
consistent naming for exported plugins

### DIFF
--- a/docs/refresh-plugin.md
+++ b/docs/refresh-plugin.md
@@ -15,11 +15,11 @@ __Example__:
 import AdJS from 'adjs';
 import DFP from 'adjs/networks/DFP';
 
-import AutoRefreshPlugin from 'adjs/plugins/AutoRefresh';
+import AutoRefresh from 'adjs/plugins/AutoRefresh';
 
 const page = new AdJS.Page(DFP, {
   plugins: [
-    AutoRefreshPlugin,
+    AutoRefresh,
   ]
 });
 ```
@@ -81,13 +81,13 @@ Configuraton on an individual Ad
 import AdJS from 'adjs';
 import DFPNetwork from 'adjs/networks/DFP';
 
-import AutoRefreshPlugin from 'adjs/plugins/AutoRefresh';
+import AutoRefresh from 'adjs/plugins/AutoRefresh';
 
 const page = new AdJS.Page(DFPNetwork);
 
 const ad = new page.createAd(el, {
   plugins: [
-    AutoRefreshPlugin
+    AutoRefresh
   ],
 
   refreshRateInSeconds: 30,

--- a/docs/responsive-plugin.md
+++ b/docs/responsive-plugin.md
@@ -16,11 +16,11 @@ __Example__:
 ```js
 import AdJS from 'adjs';
 import DFP from 'adjs/networks/DFP';
-import ResponsivePlugin from 'adjs/plugins/Responsive';
+import Responsive from 'adjs/plugins/Responsive';
 
 const page = new AdJS.Page(DFP, {
   plugins: [
-    ResponsivePlugin,
+    Responsive,
   ]
 });
 ```

--- a/src/plugins/AutoRefresh.ts
+++ b/src/plugins/AutoRefresh.ts
@@ -5,7 +5,7 @@ import GenericPlugin from './GenericPlugin';
 
 const ONE_SECOND = 1000;
 
-class AutoRefreshPlugin extends GenericPlugin {
+class AutoRefresh extends GenericPlugin {
   public timeInView: number = 0;
   private watcher?: IWatcher;
   private isRefreshing: boolean = false;
@@ -102,4 +102,4 @@ class AutoRefreshPlugin extends GenericPlugin {
   }
 }
 
-export default AutoRefreshPlugin;
+export default AutoRefresh;

--- a/src/plugins/Responsive.ts
+++ b/src/plugins/Responsive.ts
@@ -5,7 +5,7 @@ import isBetween from '../utils/isBetween';
 import throttle from '../utils/throttle';
 import GenericPlugin from './GenericPlugin';
 
-class ResponsivePlugin extends GenericPlugin {
+class Responsive extends GenericPlugin {
   public currentConfines: ICurrentConfines = {};
   private EVENT_KEY: string = 'resize';
   private THROTTLE_DURATION: number = 250;
@@ -82,4 +82,4 @@ class ResponsivePlugin extends GenericPlugin {
   }
 }
 
-export default ResponsivePlugin;
+export default Responsive;

--- a/src/plugins/Sticky.ts
+++ b/src/plugins/Sticky.ts
@@ -3,7 +3,7 @@ import { LOG_LEVELS } from '../types';
 import dispatchEvent from '../utils/dispatchEvent';
 import GenericPlugin from './GenericPlugin';
 
-class StickyPlugin extends GenericPlugin {
+class Sticky extends GenericPlugin {
   public stickybit?: StickyBits;
 
   public onCreate() {
@@ -25,4 +25,4 @@ class StickyPlugin extends GenericPlugin {
   }
 }
 
-export default StickyPlugin;
+export default Sticky;

--- a/tests/plugins/Responsive.test.ts
+++ b/tests/plugins/Responsive.test.ts
@@ -1,4 +1,4 @@
-import ResponsivePlugin from '../../src/plugins/Responsive';
+import Responsive from '../../src/plugins/Responsive';
 
 describe('ResponsivePlugin', async () => {
   const ad = {
@@ -18,9 +18,9 @@ describe('ResponsivePlugin', async () => {
 
   it('creates two identical instances', () => {
     // @ts-ignore
-    const responsivePlugin = new ResponsivePlugin(ad);
+    const responsivePlugin = new Responsive(ad);
     // @ts-ignore
-    const responsivePlugin2 = new ResponsivePlugin(ad);
+    const responsivePlugin2 = new Responsive(ad);
     expect(responsivePlugin).toEqual(responsivePlugin2);
   });
 
@@ -28,7 +28,7 @@ describe('ResponsivePlugin', async () => {
     it('throws AdJs error when breakpoints not provided', () => {
       try {
         // @ts-ignore
-        const responsivePlugin = new ResponsivePlugin(ad);
+        const responsivePlugin = new Responsive(ad);
         delete ad.configuration.breakpoints;
         responsivePlugin.beforeCreate(ad);
       } catch (e) {
@@ -39,7 +39,7 @@ describe('ResponsivePlugin', async () => {
 
     it('sets currentConfines correctly for all three screen sizes', () => {
       // @ts-ignore
-      const responsivePlugin = new ResponsivePlugin(ad);
+      const responsivePlugin = new Responsive(ad);
       ad.configuration.breakpoints = {
         mobile: { from: 0, to: 767 },
         tablet: { from: 768, to: 999 },
@@ -66,7 +66,7 @@ describe('ResponsivePlugin', async () => {
   describe('#isRefreshDisabled', () => {
     it('returns false if refreshOnBreakpoint not specified', () => {
       // @ts-ignore
-      const responsivePlugin = new ResponsivePlugin(ad);
+      const responsivePlugin = new Responsive(ad);
       const value = responsivePlugin.isRefreshDisabled();
       expect(value).toEqual(false);
     });
@@ -75,7 +75,7 @@ describe('ResponsivePlugin', async () => {
       // @ts-ignore
       ad.configuration.refreshOnBreakpoint = false;
       // @ts-ignore
-      const responsivePlugin = new ResponsivePlugin(ad);
+      const responsivePlugin = new Responsive(ad);
       const value = responsivePlugin.isRefreshDisabled();
       expect(value).toEqual(true);
     });


### PR DESCRIPTION
## Description
Some plugins were exported as `${name}Plugin` instead of `${}`.
Because all plugins are under a directory `Plugins` that extend the `GenericPlugin`, this removes Plugin from the names to match the convention of networks and the rest of the plugins themselves.

## PR Requirements
Before requesting review this criteria must be met: 
Overall test coverage >= current master?
- [x] Yes
- [ ] N.A.

Documentation included (if any behavioral changes)?
- [x] Yes
- [ ] N.A.

Backwards compatibility (if breaking change)?
- [ ] Yes
- [x] N.A.

## Release
Will this pr trigger a release i.e. `version` in `package.json` has been bumped?
- [ ] Yes
- [x] No
.
