### PR TITLE
add flag for pruning

### DIFF
--- a/docs/error.md
+++ b/docs/error.md
@@ -1,6 +1,6 @@
 # Common Errors
 
-## Error 1:
+## Error 1
 Description: An ad must be passed into the GenericPlugin class. If your Plugin inherits from GenericPlugin
 		and overrides the constructor make sure you are calling "super" and that you are passing in an
 		instance of an ad as the first parameter. Alternatively, you can hook into the onCreate method
@@ -27,23 +27,23 @@ Description: An ad must be passed into the GenericPlugin class. If your Plugin i
 		  }
  ```
   
-## Error 2:
+## Error 2
 Description: Dynamic requires are not currently supported by rollup-plugin-commonjs
 
   
-## Error 3:
+## Error 3
 Description: Ad does not have an id
 
-
-## Error 4:
+  
+## Error 4
 Description: Sizes must be defined.
 
-
-## Error 5:
+  
+## Error 5
 Description: Ad Path must be defined.
 
   
-## Error 6:
+## Error 6
 Description: Using the Networks or Plugins property on AdJS is only available when installing via script.
 If you are compiling the AdJS library locally within your project, use require to
 specify the plugin directly.
@@ -61,7 +61,7 @@ Example:
   });
  ```
   
-## Error 7:
+## Error 7
 Description: The Plugin or Network has not been included in your bundle.
 Please manually include the script tag associated with this plugin or network.
 
@@ -81,7 +81,7 @@ Example:
   </script>
  ```
   
-## Error 8:
+## Error 8
 Description: Sizes must be of type `Array` unless breakpoints have been specified
 
   

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -112,12 +112,13 @@ function createDevelopmentConfiguration({ type, file, path, name }) {
   return configuration;
 }
 
-function createProductionConfiguration({ type, file, path, name }) {
+function createProductionConfiguration({ type, file, path, name, prune = true }) {
+  console.log(prune);
   const configuration = {
     input: path,
     plugins: [
       ...BASE_PLUGINS,
-      file !== 'debug' ? productionPruning() : null,
+      prune ? productionPruning() : null,
       terser(),
     ],
     output: {
@@ -173,6 +174,7 @@ createConfiguration({
 
 configurations.push(createProductionConfiguration({
   path: './src/debug.ts',
+  prune: false,
   file: 'debug',
 }));
 


### PR DESCRIPTION
## Description
This is to replace the `file === 'debug'` single use case with a flag for pruning in production


## PR Requirements
Before requesting review this criteria must be met: 
Overall test coverage >= current master?
- [ ] Yes
- [x] N.A.

Documentation included (if any behavioral changes)?
- [ ] Yes
- [x] N.A.

Backwards compatibility (if breaking change)?
- [ ] Yes
- [x] N.A.

## Release
Will this pr trigger a release i.e. `version` in `package.json` has been bumped?
- [ ] Yes
- [x] No
