### PR TITLE
add version to global adjs object

### DIFF
--- a/docs/error.md
+++ b/docs/error.md
@@ -61,10 +61,6 @@ Example:
   });
  ```
   
-## Error 8
-Description: Sizes must be of type `Array` unless breakpoints have been specified
-
-  
 ## Error 7
 Description: The Plugin or Network has not been included in your bundle.
 Please manually include the script tag associated with this plugin or network.
@@ -84,4 +80,8 @@ Example:
 	});
   </script>
  ```
+  
+## Error 8
+Description: Sizes must be of type `Array` unless breakpoints have been specified
+
   

--- a/package-lock.json
+++ b/package-lock.json
@@ -6922,6 +6922,16 @@
         "resolve": "^1.10.0"
       }
     },
+    "rollup-plugin-replace": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-replace/-/rollup-plugin-replace-2.2.0.tgz",
+      "integrity": "sha512-/5bxtUPkDHyBJAKketb4NfaeZjL5yLZdeUihSfbF2PQMz+rSTEb8ARKoOl3UBT4m7/X+QOXJo3sLTcq+yMMYTA==",
+      "dev": true,
+      "requires": {
+        "magic-string": "^0.25.2",
+        "rollup-pluginutils": "^2.6.0"
+      }
+    },
     "rollup-plugin-terser": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-4.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./core.js",
   "types": "./types.d.ts",
   "scripts": {
-    "build": "npm run clean && rollup -c; bash ./bundle.sh",
+    "build": "npm run clean && rollup -c --environment VERSION:$npm_package_version; bash ./bundle.sh",
     "clean": "rm -rf ./build && rm -f docs/error.md",
     "docs": "docsify serve docs",
     "lint": "tslint -c tslint.json 'src/**/*.ts'",
@@ -46,6 +46,7 @@
     "rollup-plugin-commonjs": "^9.3.4",
     "rollup-plugin-copy": "^2.0.1",
     "rollup-plugin-node-resolve": "^4.2.4",
+    "rollup-plugin-replace": "^2.2.0",
     "rollup-plugin-terser": "^4.0.4",
     "rollup-plugin-typescript": "^1.0.1",
     "source-map-loader": "^0.2.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,7 @@
 // rollup.config.js
 import commonjs from 'rollup-plugin-commonjs';
 import nodeResolve from 'rollup-plugin-node-resolve';
+import replace from 'rollup-plugin-replace';
 import typescript from 'rollup-plugin-typescript';
 import { terser } from "rollup-plugin-terser";
 import copy from 'rollup-plugin-copy';
@@ -24,6 +25,7 @@ const FILES_TO_COPY = [
 
 const BASE_PLUGINS = [
   typescript(),
+  replace({ __VERSION__: process.env.VERSION }),
   nodeResolve(),
   commonjs(),
   templateLiteralIndentFix(),
@@ -113,7 +115,6 @@ function createDevelopmentConfiguration({ type, file, path, name }) {
 }
 
 function createProductionConfiguration({ type, file, path, name, prune = true }) {
-  console.log(prune);
   const configuration = {
     input: path,
     plugins: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,7 @@ const AdJS = {
   Vendors,
   DEBUG: Debug,
   activeCorrelatorId: null,
+  Version: '__VERSION__',
 };
 
 /*

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ const AdJS = {
   Vendors,
   DEBUG: Debug,
   activeCorrelatorId: null,
-  Version: '__VERSION__',
+  VERSION: '__VERSION__',
 };
 
 /*


### PR DESCRIPTION
## Description
Adds `AdJS.VERSION` which is replaced in roll up process.
Documentation will be added for this while updating all docs prior to V2

## PR Requirements
Before requesting review this criteria must be met: 
Overall test coverage >= current master?
- [x] Yes
- [ ] N.A.

Documentation included (if any behavioral changes)?
- [ ] Yes
- [x] N.A.

Backwards compatibility (if breaking change)?
- [ ] Yes
- [x] N.A.

## Release
Will this pr trigger a release i.e. `version` in `package.json` has been bumped?
- [ ] Yes
- [x] No

![Screen Shot 2019-06-17 at 10 59 11 AM](https://user-images.githubusercontent.com/10228768/59625759-fba4ab80-90ee-11e9-8882-31f80ec6d4bd.png)