### PR TITLE
GPT breakpoint size bug

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -55,22 +55,22 @@
     <!-- <script type="text/javascript" src="http://localhost:8080/build/umd/bundle.production.min.js"></script> -->
 
     <!-- Development modular --->
-    <!-- <script type="text/javascript" src="http://localhost:8080/build/umd/core.development.js"></script>
+    <script type="text/javascript" src="http://localhost:8080/build/umd/core.development.js"></script>
     <script type="text/javascript" src="http://localhost:8080/build/umd/networks.dfp.development.js"></script>
     <script type="text/javascript" src="http://localhost:8080/build/umd/plugins.developertools.development.js"></script>
     <script type="text/javascript" src="http://localhost:8080/build/umd/plugins.autorender.development.js"></script>
     <script type="text/javascript" src="http://localhost:8080/build/umd/plugins.sticky.development.js"></script>
     <script type="text/javascript" src="http://localhost:8080/build/umd/plugins.autorefresh.development.js"></script>
-    <script type="text/javascript" src="http://localhost:8080/build/umd/plugins.responsive.development.js"></script> -->
+    <script type="text/javascript" src="http://localhost:8080/build/umd/plugins.responsive.development.js"></script>
 
     <!-- Production modular --->
-    <script type="text/javascript" src="http://localhost:8080/build/umd/core.production.min.js"></script>
+    <!-- <script type="text/javascript" src="http://localhost:8080/build/umd/core.production.min.js"></script>
     <script type="text/javascript" src="http://localhost:8080/build/umd/networks.dfp.production.min.js"></script>
     <script type="text/javascript" src="http://localhost:8080/build/umd/plugins.developertools.production.min.js"></script>
     <script type="text/javascript" src="http://localhost:8080/build/umd/plugins.autorender.production.min.js"></script>
     <script type="text/javascript" src="http://localhost:8080/build/umd/plugins.sticky.production.min.js"></script>
     <script type="text/javascript" src="http://localhost:8080/build/umd/plugins.autorefresh.production.min.js"></script>
-    <script type="text/javascript" src="http://localhost:8080/build/umd/plugins.responsive.production.min.js"></script>
+    <script type="text/javascript" src="http://localhost:8080/build/umd/plugins.responsive.production.min.js"></script> -->
 
     <script type="text/javascript">
       // import. (manipulated)
@@ -98,7 +98,7 @@
 
       // monetize.
       const ad = mainPage.createAd(el, {
-        path: '/123456/sports',
+        path: '/2620/nbcnews/homepage_2',
 
         /*
           for use without breakpoints

--- a/demo/index.html
+++ b/demo/index.html
@@ -55,22 +55,22 @@
     <!-- <script type="text/javascript" src="http://localhost:8080/build/umd/bundle.production.min.js"></script> -->
 
     <!-- Development modular --->
-    <script type="text/javascript" src="http://localhost:8080/build/umd/core.development.js"></script>
+    <!-- <script type="text/javascript" src="http://localhost:8080/build/umd/core.development.js"></script>
     <script type="text/javascript" src="http://localhost:8080/build/umd/networks.dfp.development.js"></script>
     <script type="text/javascript" src="http://localhost:8080/build/umd/plugins.developertools.development.js"></script>
     <script type="text/javascript" src="http://localhost:8080/build/umd/plugins.autorender.development.js"></script>
     <script type="text/javascript" src="http://localhost:8080/build/umd/plugins.sticky.development.js"></script>
     <script type="text/javascript" src="http://localhost:8080/build/umd/plugins.autorefresh.development.js"></script>
-    <script type="text/javascript" src="http://localhost:8080/build/umd/plugins.responsive.development.js"></script>
+    <script type="text/javascript" src="http://localhost:8080/build/umd/plugins.responsive.development.js"></script> -->
 
     <!-- Production modular --->
-    <!-- <script type="text/javascript" src="http://localhost:8080/build/umd/core.production.min.js"></script>
+    <script type="text/javascript" src="http://localhost:8080/build/umd/core.production.min.js"></script>
     <script type="text/javascript" src="http://localhost:8080/build/umd/networks.dfp.production.min.js"></script>
     <script type="text/javascript" src="http://localhost:8080/build/umd/plugins.developertools.production.min.js"></script>
     <script type="text/javascript" src="http://localhost:8080/build/umd/plugins.autorender.production.min.js"></script>
     <script type="text/javascript" src="http://localhost:8080/build/umd/plugins.sticky.production.min.js"></script>
     <script type="text/javascript" src="http://localhost:8080/build/umd/plugins.autorefresh.production.min.js"></script>
-    <script type="text/javascript" src="http://localhost:8080/build/umd/plugins.responsive.production.min.js"></script> -->
+    <script type="text/javascript" src="http://localhost:8080/build/umd/plugins.responsive.production.min.js"></script>
 
     <script type="text/javascript">
       // import. (manipulated)
@@ -98,7 +98,7 @@
 
       // monetize.
       const ad = mainPage.createAd(el, {
-        path: '/2620/nbcnews/homepage_2',
+        path: '/123456/sports',
 
         /*
           for use without breakpoints

--- a/src/Ad.ts
+++ b/src/Ad.ts
@@ -1,12 +1,11 @@
 import {
-  IAd,
-  IAdConfiguration, IAdEventListener,
-  INetwork, INetworkInstance, IPlugin, IPluginConstructorOrSingleton, IPluginHook, IVendor,
+  IAd, IAdConfiguration, IAdEventListener,
+  INetwork, INetworkInstance, IPlugin, IPluginConstructorOrSingleton,
+  IVendor,
   Maybe,
 } from './types';
 
 import EVENTS from './Events';
-import AdJS from './index';
 import Page from './Page';
 import insertElement from './utils/insertElement';
 import seriallyResolvePromises from './utils/seriallyResolvePromises';
@@ -25,18 +24,6 @@ function validateSizes(configuration: IAdConfiguration): void {
     throw new Error('Sizes must be of type `Array` unless breakpoints have been specified');
   }
 }
-
-const DEFAULT_CONFIGURATION: IAdConfiguration = {
-  autoRender: true,
-  autoRefresh: true,
-  logging: true,
-  overlay: true,
-  offset: 0,
-  refreshRateInSeconds: 30,
-  targeting: {},
-  breakpoints: {},
-  refreshOnBreakpoint: true,
-};
 
 // Define LifeCycle Method will automatically wrap each
 // lifecycle with important items such as "queue" when frozen,

--- a/src/plugins/Responsive.ts
+++ b/src/plugins/Responsive.ts
@@ -1,5 +1,6 @@
 import { ICurrentConfines } from '../types';
 import { LOG_LEVELS } from '../types';
+import breakpointHandler from '../utils/breakpointHandler';
 import dispatchEvent from '../utils/dispatchEvent';
 import isBetween from '../utils/isBetween';
 import throttle from '../utils/throttle';
@@ -55,25 +56,8 @@ class Responsive extends GenericPlugin {
   }
 
   public determineCurrentBreakpoint() {
-    const { breakpoints } = this.ad.configuration;
-    let breakpointSpecifiedForViewWidth: boolean = false;
-
-    if (!breakpoints) {
-      return;
-    }
-
-    Object.keys(breakpoints).forEach((key) => {
-      const { from, to } = breakpoints[key];
-
-      if (isBetween(window.innerWidth, from, to)) {
-        breakpointSpecifiedForViewWidth = true;
-        this.currentConfines = { from, to };
-      }
-    });
-
-    if (!breakpointSpecifiedForViewWidth) {
-      this.currentConfines = {};
-    }
+    const { sizes = [], breakpoints } = this.ad.configuration;
+    this.currentConfines = breakpointHandler(sizes, breakpoints);
   }
 
   public isRefreshDisabled() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -153,6 +153,8 @@ export interface IAdSizes {
 export interface ICurrentConfines {
   from?: number;
   to?: number;
+  breakpoint?: string;
+  sizesSpecified?: boolean;
 }
 
 export interface IAdConfiguration {

--- a/src/utils/breakpointHandler.ts
+++ b/src/utils/breakpointHandler.ts
@@ -1,16 +1,12 @@
 import { IAdBreakpoints, IAdSizes, ICurrentConfines } from '../types';
 import isBetween from './isBetween';
 
-/*
-  breakpointHandler
-  If no breakpoints provided, return truthy value {} (when called by DFP)
-  Determine current breakpoint viewport falls within
-*/
 const breakpointHandler = (sizes: IAdSizes | any, breakpoints?: IAdBreakpoints): ICurrentConfines => {
   let currentConfines: ICurrentConfines = {};
 
   if (!breakpoints) {
-    return {};
+    // Ad is not using responsive plugin
+    return { sizesSpecified: true };
   }
 
   Object.keys(breakpoints).forEach((key) => {

--- a/src/utils/breakpointHandler.ts
+++ b/src/utils/breakpointHandler.ts
@@ -1,0 +1,32 @@
+import { IAdBreakpoints, IAdSizes, ICurrentConfines } from '../types';
+import isBetween from './isBetween';
+
+/*
+  breakpointHandler
+  If no breakpoints provided, return truthy value {} (when called by DFP)
+  Determine current breakpoint viewport falls within
+*/
+const breakpointHandler = (sizes: IAdSizes | any, breakpoints?: IAdBreakpoints): ICurrentConfines => {
+  let currentConfines: ICurrentConfines = {};
+
+  if (!breakpoints) {
+    return {};
+  }
+
+  Object.keys(breakpoints).forEach((key) => {
+    const { from, to } = breakpoints[key];
+
+    if (isBetween(window.innerWidth, from, to)) {
+      currentConfines = {
+        from,
+        to,
+        breakpoint: key,
+        sizesSpecified: !!(sizes[key] && sizes[key].length > 0),
+      };
+    }
+  });
+
+  return currentConfines;
+};
+
+export default breakpointHandler;

--- a/tests/plugins/Responsive.test.ts
+++ b/tests/plugins/Responsive.test.ts
@@ -1,4 +1,5 @@
 import Responsive from '../../src/plugins/Responsive';
+import { ICurrentConfines } from '../../src/types';
 
 describe('ResponsivePlugin', async () => {
   const ad = {
@@ -37,9 +38,10 @@ describe('ResponsivePlugin', async () => {
       }
     });
 
-    it('sets currentConfines correctly for all three screen sizes', () => {
+    it('sets currentConfines correctly', () => {
       // @ts-ignore
       const responsivePlugin = new Responsive(ad);
+      let expected: ICurrentConfines = {};
       ad.configuration.breakpoints = {
         mobile: { from: 0, to: 767 },
         tablet: { from: 768, to: 999 },
@@ -49,17 +51,8 @@ describe('ResponsivePlugin', async () => {
       // @ts-ignore
       global.innerWidth = 500;
       responsivePlugin.beforeCreate(ad);
-      expect(responsivePlugin.currentConfines).toEqual({ from: 0, to: 767 });
-
-      // @ts-ignore
-      global.innerWidth = 980;
-      responsivePlugin.beforeCreate(ad);
-      expect(responsivePlugin.currentConfines).toEqual({ from: 768, to: 999 });
-
-      // @ts-ignore
-      global.innerWidth = 1240;
-      responsivePlugin.beforeCreate(ad);
-      expect(responsivePlugin.currentConfines).toEqual({ from: 1000, to: Infinity });
+      expected = { from: 0, to: 767, breakpoint: 'mobile', sizesSpecified: false };
+      expect(responsivePlugin.currentConfines).toEqual(expected);
     });
   });
 

--- a/tests/utils/breakpointsHandler.test.ts
+++ b/tests/utils/breakpointsHandler.test.ts
@@ -56,13 +56,13 @@ describe('breakpointHandler', async () => {
     expect(desktop).toEqual(expected);
   });
 
-  it('returns {} when breakpoints not provided', () => {
+  it('returns { sizesSpecified: true } when breakpoints not provided', () => {
     delete configuration.breakpoints;
 
     // @ts-ignore
     global.innerWidth = 500;
     const mobile = breakpointHandler(configuration.sizes, configuration.breakpoints);
-    expected = {};
+    expected = { sizesSpecified: true };
     expect(mobile).toEqual(expected);
   });
 });

--- a/tests/utils/breakpointsHandler.test.ts
+++ b/tests/utils/breakpointsHandler.test.ts
@@ -1,0 +1,68 @@
+import { ICurrentConfines } from '../../src/types';
+import breakpointHandler from '../../src/utils/breakpointHandler';
+
+describe('breakpointHandler', async () => {
+  let expected: ICurrentConfines = {};
+  const configuration: any = {
+    breakpoints: {
+      mobile: { from: 0, to: 767 },
+      tablet: { from: 768, to: 999 },
+      desktop: { from: 1000, to: Infinity },
+    },
+    sizes: {},
+  };
+
+  it('returns correct results per screen size', () => {
+    // @ts-ignore
+    global.innerWidth = 500;
+    const mobile = breakpointHandler(configuration.sizes, configuration.breakpoints);
+    expected = { from: 0, to: 767, breakpoint: 'mobile', sizesSpecified: false };
+    expect(mobile).toEqual(expected);
+
+    // @ts-ignore
+    global.innerWidth = 980;
+    const tablet = breakpointHandler(configuration.sizes, configuration.breakpoints);
+    expected = { from: 768, to: 999, breakpoint: 'tablet', sizesSpecified: false };
+    expect(tablet).toEqual(expected);
+
+    // @ts-ignore
+    global.innerWidth = 1001;
+    const desktop = breakpointHandler(configuration.sizes, configuration.breakpoints);
+    expected = { from: 1000, to: Infinity, breakpoint: 'desktop', sizesSpecified: false };
+    expect(desktop).toEqual(expected);
+  });
+
+  it('returns sizesSpecified=true when appropriate', () => {
+    configuration.sizes.mobile = [[250, 250]];
+    configuration.sizes.tablet = [];
+    configuration.sizes.desktop = [[500, 500]];
+
+    // @ts-ignore
+    global.innerWidth = 500;
+    const mobile = breakpointHandler(configuration.sizes, configuration.breakpoints);
+    expected = { from: 0, to: 767, breakpoint: 'mobile', sizesSpecified: true };
+    expect(mobile).toEqual(expected);
+
+    // @ts-ignore
+    global.innerWidth = 980;
+    const tablet = breakpointHandler(configuration.sizes, configuration.breakpoints);
+    expected = { from: 768, to: 999, breakpoint: 'tablet', sizesSpecified: false };
+    expect(tablet).toEqual(expected);
+
+    // @ts-ignore
+    global.innerWidth = 1001;
+    const desktop = breakpointHandler(configuration.sizes, configuration.breakpoints);
+    expected = { from: 1000, to: Infinity, breakpoint: 'desktop', sizesSpecified: true };
+    expect(desktop).toEqual(expected);
+  });
+
+  it('returns {} when breakpoints not provided', () => {
+    delete configuration.breakpoints;
+
+    // @ts-ignore
+    global.innerWidth = 500;
+    const mobile = breakpointHandler(configuration.sizes, configuration.breakpoints);
+    expected = {};
+    expect(mobile).toEqual(expected);
+  });
+});


### PR DESCRIPTION
## Description
Bug: If a user doesn't provide ad sizes for a certain defined breakpoint, when the window is resized to that breakpoint, it calls refresh but there is no response from GPT -- therefore the promise chain gets hung up and doesn't listen to subsequent refresh calls.

Fix: Check if sizes are provided before calling refresh. If not, call `DFP.clear().then(resolve)`.

## PR Requirements
Before requesting review this criteria must be met: 
Overall test coverage >= current master?
- [x] Yes
- [ ] N.A.

Documentation included (if any behavioral changes)?
- [ ] Yes
- [x] N.A.

Backwards compatibility (if breaking change)?
- [ ] Yes
- [x] N.A.

## Release
Will this pr trigger a release i.e. `version` in `package.json` has been bumped?
- [ ] Yes
- [x] No
