### PR TITLE
Bugfix/is empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adjs",
-  "version": "2.0.0-beta.13",
+  "version": "2.0.0-beta.14",
   "description": "Ad Library to simplify and optimize integration with ad networks such as DFP",
   "main": "./core.js",
   "types": "./types.d.ts",

--- a/src/Ad.ts
+++ b/src/Ad.ts
@@ -129,6 +129,7 @@ class Ad implements IAd {
   // TODO: Rethink
   public correlatorId?: string;
   public id: number;
+  public isEmpty: boolean = true;
 
   public state: { [key: string]: boolean } = {
     creating: false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ export interface IAdEventListener {
 export interface IAd {
   id: number;
 
+  isEmpty: boolean;
   configuration: IAdConfiguration;
 
   container: HTMLElement;

--- a/src/utils/breakpointHandler.ts
+++ b/src/utils/breakpointHandler.ts
@@ -4,9 +4,9 @@ import isBetween from './isBetween';
 const breakpointHandler = (sizes: IAdSizes | any, breakpoints?: IAdBreakpoints): ICurrentConfines => {
   let currentConfines: ICurrentConfines = {};
 
-  if (!breakpoints) {
+  if (Array.isArray(sizes) || !breakpoints) {
     // Ad is not using responsive plugin
-    return { sizesSpecified: true };
+    return { sizesSpecified: !!sizes.length };
   }
 
   Object.keys(breakpoints).forEach((key) => {

--- a/tests/plugins/Responsive.test.ts
+++ b/tests/plugins/Responsive.test.ts
@@ -5,6 +5,7 @@ describe('ResponsivePlugin', async () => {
   const ad = {
     configuration: {
       breakpoints: {},
+      sizes: {},
     },
     container: {},
     el: {},
@@ -42,6 +43,11 @@ describe('ResponsivePlugin', async () => {
       // @ts-ignore
       const responsivePlugin = new Responsive(ad);
       let expected: ICurrentConfines = {};
+
+      ad.configuration.sizes = {
+        mobile: [],
+      };
+
       ad.configuration.breakpoints = {
         mobile: { from: 0, to: 767 },
         tablet: { from: 768, to: 999 },

--- a/tests/utils/breakpointsHandler.test.ts
+++ b/tests/utils/breakpointsHandler.test.ts
@@ -56,12 +56,22 @@ describe('breakpointHandler', async () => {
     expect(desktop).toEqual(expected);
   });
 
+  it('returns { sizesSpecified: false } when breakpoints not provided and sizes empty', () => {
+    delete configuration.breakpoints;
+
+    // @ts-ignore
+    global.innerWidth = 500;
+    const mobile = breakpointHandler([], configuration.breakpoints);
+    expected = { sizesSpecified: false };
+    expect(mobile).toEqual(expected);
+  });
+
   it('returns { sizesSpecified: true } when breakpoints not provided', () => {
     delete configuration.breakpoints;
 
     // @ts-ignore
     global.innerWidth = 500;
-    const mobile = breakpointHandler(configuration.sizes, configuration.breakpoints);
+    const mobile = breakpointHandler([[300, 250]], configuration.breakpoints);
     expected = { sizesSpecified: true };
     expect(mobile).toEqual(expected);
   });


### PR DESCRIPTION
## Description
When an ad returns empty there is no way for the consumer to get this info. This exposes it via an empty flag on the ad itself... I.E. `ad.after('render', (ad) => ad.isEmpty));`

## PR Requirements
Before requesting review this criteria must be met: 
Overall test coverage >= current master?
- [X ] Yes
- [ ] N.A.

Documentation included (if any behavioral changes)?
- [ ] Yes
- [ X] N.A.

Backwards compatibility (if breaking change)?
- [ X] Yes
- [ ] N.A.

## Release
Will this pr trigger a release i.e. `version` in `package.json` has been bumped?
- [ X] Yes
- [ ] No

## Screenshots
If U.I. component, include screenshots or video screen capture showing
behavior and responsive styling below.
