### PR TITLE
Correct dispatched message for beforeRefresh

### DIFF
--- a/src/plugins/DeveloperTools.ts
+++ b/src/plugins/DeveloperTools.ts
@@ -72,7 +72,7 @@ if ('__DEV__') {
     }
 
     public beforeRefresh() {
-      dispatchEvent(this.ad.id, LOG_LEVELS.INFO, 'DeveloperTools Plugin', 'Ad render has completed.');
+      dispatchEvent(this.ad.id, LOG_LEVELS.INFO, 'DeveloperTools Plugin', 'Refresh has been called on ad.');
     }
 
     public onRefresh() {


### PR DESCRIPTION
## Description
Message was incorrect for DeveloperTools beforeRefresh event.
Updated to 'Refresh has been called on ad.'

## PR Requirements
Before requesting review this criteria must be met: 
Overall test coverage >= current master?
- [x] Yes
- [ ] N.A.

Documentation included (if any behavioral changes)?
- [ ] Yes
- [x] N.A.

Backwards compatibility (if breaking change)?
- [ ] Yes
- [x] N.A.

## Release
Will this pr trigger a release i.e. `version` in `package.json` has been bumped?
- [ ] Yes
- [x] No
