### PR TITLE
[JR] Fix #103: Bugfix/restore original container style on destroy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adjs",
-  "version": "2.0.0-beta.24",
+  "version": "2.0.0-beta.25",
   "description": "Ad Library to simplify and optimize integration with ad networks such as DFP",
   "main": "./core.js",
   "types": "./types.d.ts",

--- a/src/plugins/Sticky.ts
+++ b/src/plugins/Sticky.ts
@@ -23,6 +23,7 @@ class Sticky extends GenericPlugin {
   public listener?: any;
   public boundary?: IBoundary;
   public originalStyle?: any;
+  public originalStyleCssText?: any;
 
   public onCreate() {
     if (!this.isEnabled('sticky')) {
@@ -31,7 +32,16 @@ class Sticky extends GenericPlugin {
 
     const { container, configuration } = this.ad;
     const { stickyOffset = 0 } = configuration;
-    this.originalStyle = container.style;
+
+    this.originalStyle = {};
+
+    // Clone to avoid container.style value assigment overriding original style values
+    Object.entries(container.style).forEach(([_, cssProperty]) => {
+      this.originalStyle[cssProperty] = container.style.getPropertyValue(cssProperty);
+    });
+
+    // Simplify style restoration on destroy
+    this.originalStyleCssText = container.style.cssText;
 
     container.style.position = 'sticky';
     container.style.top = `${stickyOffset}px`;
@@ -58,9 +68,7 @@ class Sticky extends GenericPlugin {
   public cleanup() {
     const { container } = this.ad;
 
-    container.style.position = this.originalStyle.position;
-    container.style.top = this.originalStyle.top;
-    container.style.transform = this.originalStyle.transform;
+    container.style.cssText = this.originalStyleCssText;
 
     if (this.listener) {
       window.removeEventListener('scroll', this.listener);

--- a/tests/plugins/Sticky.test.ts
+++ b/tests/plugins/Sticky.test.ts
@@ -55,5 +55,45 @@ describe('Sticky', () => {
     const sticky: any = new Sticky(ad);
     sticky.onCreate();
     expect(ad.container.style.top).toBe('3px');
-  })
+  });
+
+  it('reverts sticky container to original styles when destroyed', () => {
+    const dummyParent: any = document.createElement('div');
+    const dummyAdContainer: any = document.createElement('div');
+    const originalDummyAdContainerPosition = 'relative'
+    dummyAdContainer.style.position = originalDummyAdContainerPosition;
+    
+    dummyParent.appendChild(dummyAdContainer);
+
+    const ad = {
+      configuration: {
+        breakpoints: {},
+        stickyOffset: 3,
+        sticky: true
+      },
+      container: dummyAdContainer,
+      el: {},
+      network: 'DFP',
+      render: () => {},
+      refresh: jest.fn(() => {}),
+      clear: () => {},
+      destroy: () => {},
+      freeze: () => {},
+      unfreeze: () => {}
+    }
+
+    // @ts-ignore
+    const sticky: any = new Sticky(ad);
+
+    // Container set to sticky
+    sticky.onCreate();
+ 
+    // Ad container styles like position should be overridden
+    expect(ad.container.style.position).not.toEqual(originalDummyAdContainerPosition);
+
+    // Clean up should revert styles to original
+    sticky.onDestroy();
+    
+    expect(ad.container.style.position).toEqual(originalDummyAdContainerPosition);
+  });
 });


### PR DESCRIPTION
## Description
- if bugfix:
  - Explanation of the problems behavior & repro steps, the code culprit and the solution.

Writing some tests to familiarize with ad.js (+ bonus increase coverage) and came across:

```
    this.originalStyle = container.style;

    container.style.position = 'sticky';
    container.style.top = `${stickyOffset}px`;
```
https://github.com/Econify/ad.js/blob/master/src/plugins/Sticky.ts#L34

Understanding is original style is a reference to container.style so the next line that sets the value of container.style overwrites the original value to be preserved in this.originalStyle (used for restoration in .onDestroy -> .cleanUp). As is this means position and top if set are never restored to their original values onDestroy -> cleanUp.

## PR Requirements
Before requesting review this criteria must be met: 
Overall test coverage >= current master?
- [X] Yes
- [ ] N.A.

Documentation included (if any behavioral changes)?
- [ ] Yes
- [X] N.A.

Backwards compatibility (if breaking change)?
- [ ] Yes
- [X] N.A.

## Release
Will this pr trigger a release i.e. `version` in `package.json` has been bumped?
- [X] Yes
- [ ] No

## Screenshots
If U.I. component, include screenshots or video screen capture showing
behavior and responsive styling below.
