### PR TITLE
[MM] AutoRender clear on exit viewport -- 2.0.0-beta.25

### DIFF
--- a/docs/lazy-load-plugin.md
+++ b/docs/lazy-load-plugin.md
@@ -68,6 +68,7 @@ The Auto Render Plugin adds two options to ad instantiation
 |autoRender|false|When set to true, AdJS will automatically render the ad when it enters the viewport (plus the offset provided if any)|
 |renderOffset|0|A measurement in pixels or percentage that AdJS will use to determine how far away from the viewport to load the ad|
 |enableByScroll|false|If enabled, offsets which evaluate to in view on load will not allow execution until user scrolls|
+|clearOnExitViewport|false|If enabled, ad will be cleared when scrolled back out of view|
 
 ## Examples
 
@@ -85,6 +86,7 @@ const page = new AdJS.Page(Network, {
     autoLoad: true,
     renderOffset: 0,
     enableByScroll: false,
+    clearOnExitViewport: false,
   }
 });
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adjs",
-  "version": "2.0.0-beta.24",
+  "version": "2.0.0-beta.25",
   "description": "Ad Library to simplify and optimize integration with ad networks such as DFP",
   "main": "./core.js",
   "types": "./types.d.ts",

--- a/src/plugins/AutoRender.ts
+++ b/src/plugins/AutoRender.ts
@@ -28,6 +28,17 @@ class AutoRender extends GenericPlugin {
     dispatchEvent(this.ad.id, LOG_LEVELS.INFO, 'AutoRender Plugin', 'Ad has entered the viewport. Calling render().');
     this.ad.render();
   }
+
+  private onExitViewport = () => {
+    const { clearOnExitViewport } = this.ad.configuration;
+
+    if (!this.isEnabled('autoRender') || !clearOnExitViewport) {
+      return;
+    }
+
+    dispatchEvent(this.ad.id, LOG_LEVELS.INFO, 'AutoRender Plugin', 'Ad has exited the viewport. Calling clear().');
+    this.ad.clear();
+  }
 }
 
 export default AutoRender;

--- a/src/plugins/AutoRender.ts
+++ b/src/plugins/AutoRender.ts
@@ -11,12 +11,20 @@ class AutoRender extends GenericPlugin {
 
     const {
       container,
-      configuration: { renderOffset, offset, enableByScroll },
+      configuration: { renderOffset, offset, enableByScroll, clearOnExitViewport },
       el: { id } } = this.ad;
 
     const finalOffset = renderOffset || offset || 0;
 
-    ScrollMonitor.subscribe(id, container, finalOffset, this.onEnterViewport, undefined, undefined, enableByScroll);
+    ScrollMonitor.subscribe(
+      id,
+      container,
+      finalOffset,
+      this.onEnterViewport,
+      undefined,
+      clearOnExitViewport ? this.onExitViewport : undefined,
+      enableByScroll,
+    );
     dispatchEvent(this.ad.id, LOG_LEVELS.INFO, 'AutoRender Plugin', `Ad's scroll monitor has been created.`);
   }
 
@@ -30,9 +38,7 @@ class AutoRender extends GenericPlugin {
   }
 
   private onExitViewport = () => {
-    const { clearOnExitViewport } = this.ad.configuration;
-
-    if (!this.isEnabled('autoRender') || !clearOnExitViewport) {
+    if (!this.isEnabled('autoRender')) {
       return;
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,6 +165,7 @@ export interface IAdConfiguration {
   autoRender?: boolean;
   sticky?: boolean;
   enableByScroll?: boolean;
+  clearOnExitViewport?: boolean;
 
   breakpoints?: IAdBreakpoints;
   offset?: number;


### PR DESCRIPTION
## Description
This allows users to pass `clearOnExitViewport` as a configuration option on AutoRender plugin.
If enabled, the ad will clear when it leaves the viewport.


## PR Requirements
Before requesting review this criteria must be met: 
Overall test coverage >= current master?
- [ ] Yes
- [x] N.A.

Documentation included (if any behavioral changes)?
- [x] Yes
- [ ] N.A.

Backwards compatibility (if breaking change)?
- [x] Yes
- [ ] N.A.

## Release
Will this pr trigger a release i.e. `version` in `package.json` has been bumped?
- [x] Yes
- [ ] No

## Screenshots
If U.I. component, include screenshots or video screen capture showing
behavior and responsive styling below.
