### PR TITLE
[JK] Modified default ad slot size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adjs",
-  "version": "2.0.0-beta.25",
+  "version": "2.0.0-beta.26",
   "description": "Ad Library to simplify and optimize integration with ad networks such as DFP",
   "main": "./core.js",
   "types": "./types.d.ts",

--- a/src/networks/DFP.ts
+++ b/src/networks/DFP.ts
@@ -39,7 +39,8 @@ class DfpAd implements INetworkInstance {
     this.breakpoints = breakpoints;
 
     googletag.cmd.push(() => {
-      const adSizes = Array.isArray(sizes) ? sizes : [];
+      const adSizes = Array.isArray(sizes) ? sizes : [0, 0];
+
       this.slot = googletag.defineSlot(path, adSizes, this.id);
 
       if (targeting) {


### PR DESCRIPTION
## Description
- if feature:
  - Overview of assigned task including architecture and code changes required and acceptance criteria
- if bugfix:
  - Explanation of the problems behavior & repro steps, the code culprit and the solution.

Bugfix:
Use responsive ads with breakpoints
`adSizes` defaults to an empty array which triggers the following warning:
<img width="714" alt="Screen Shot 2019-12-10 at 15 26 34" src="https://user-images.githubusercontent.com/7142627/70649458-31989780-1c1b-11ea-9cf1-86b9dc0f257a.png">
resolve #112 

## PR Requirements
Before requesting review this criteria must be met: 
Overall test coverage >= current master?
- [X] Yes
- [ ] N.A.

Documentation included (if any behavioral changes)?
- [X] Yes
- [ ] N.A.

Backwards compatibility (if breaking change)?
- [X] Yes
- [ ] N.A.

## Release
Will this pr trigger a release i.e. `version` in `package.json` has been bumped?
- [X] Yes
- [ ] No

## Screenshots
If U.I. component, include screenshots or video screen capture showing
behavior and responsive styling below.
