### PR TITLE
[RK] Fix amazon linux 2 build

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -18,6 +18,7 @@ phases:
       - LOCAL_VERSION=$(node -e "console.log(require('./package.json').version)")
       - if [ -z $LOCAL_VERSION ]; then echo "Version is missing from package.json. Exiting build."; exit 1; fi
       - |
+        set -e
         if [ $LOCAL_VERSION = $CURRENT_PUBLISHED_VERSION ]; then
           echo "Version is unchanged. NPM publish is not required."
         else

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -22,8 +22,7 @@ phases:
           echo "Version is unchanged. NPM publish is not required."
         else
           echo "New version detected. Publishing to NPM."
-          sudo apt-get update
-          sudo apt-get install build-essential -y
-          wget https://github.com/stedolan/jq/releases/download/jq-1.5/jq-1.5.tar.gz && tar xzf jq-1.5.tar.gz && cd jq-1.5 && ./configure && make && make install && cd .. 
+          yum update -y
+          yum install -y make glibc-devel gcc patch jq
           NPM_TOKEN=$(aws ssm get-parameter --name npm-publish-token --with-decryption | jq '.Parameter.Value') npm run release
         fi

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,6 +6,7 @@ phases:
       nodejs: 12
     commands:
       - npm install
+      - yum update -y && yum install -y jq
   pre_build:
     commands:
       - npm run lint
@@ -15,7 +16,7 @@ phases:
       - echo 'Verifying npm publish is required'
       - CURRENT_PUBLISHED_VERSION=$(npm info adjs version)
       - if [ -z $CURRENT_PUBLISHED_VERSION ]; then echo "Could not find latest published version. Exiting build."; exit 1; fi
-      - LOCAL_VERSION=$(node -e "console.log(require('./package.json').version)")
+      - LOCAL_VERSION=$(cat package.json | jq '.version' | tr -d '"' | tr -d '\n')
       - if [ -z $LOCAL_VERSION ]; then echo "Version is missing from package.json. Exiting build."; exit 1; fi
       - |
         set -e
@@ -23,7 +24,5 @@ phases:
           echo "Version is unchanged. NPM publish is not required."
         else
           echo "New version detected. Publishing to NPM."
-          yum update -y
-          yum install -y make glibc-devel gcc patch jq
           NPM_TOKEN=$(aws ssm get-parameter --name npm-publish-token --with-decryption | jq '.Parameter.Value') npm run release
         fi


### PR DESCRIPTION
## Description
In upgrading our dependencies, the version of node that the codebuild runs was updated. To access newer versions of the node build image, we upgraded to amazon linux 2 which uses yum instead of apt-get. This pull request updates the build commands to use yum instead of apt-get.

## PR Requirements
Before requesting review this criteria must be met: 
Overall test coverage >= current master?
- [X] Yes
- [ ] N.A.

Documentation included (if any behavioral changes)?
- [ ] Yes
- [X] N.A.

Backwards compatibility (if breaking change)?
- [ ] Yes
- [X] N.A.

## Release
Will this pr trigger a release i.e. `version` in `package.json` has been bumped?
- [X] Yes (it was bumped in previous PR, release failed)
- [ ] No

## Screenshots
If U.I. component, include screenshots or video screen capture showing
behavior and responsive styling below.
