### PR TITLE
[DA] Implement auto refresh correlator option

### DIFF
--- a/docs/refresh-plugin.md
+++ b/docs/refresh-plugin.md
@@ -56,6 +56,7 @@ The AutoRefresh Plugin adds two options to ad instantiation
 |---|---|---|
 |refreshRateInSeconds|30|Duration the ad must be in view (in seconds) before refreshing the unit. 30 Seconds is recommended. If set to 0, the ad will not refresh|
 |refreshLimit|null|Allows you to specify a maximum number of times the ad slot can be refreshed|
+|refreshResetsCorrelator|false|If true, requests the network to reset the correlator when refreshing|
 
 ## Examples
 
@@ -71,7 +72,8 @@ const page = new AdJS.Page(Network, {
 
   defaults: {
     refreshRateInSeconds: 30,
-    refreshLimit: 3
+    refreshLimit: 3,
+    refreshResetsCorrelator: false
   }
 });
 ```
@@ -91,6 +93,7 @@ const ad = new page.createAd(el, {
   ],
 
   refreshRateInSeconds: 30,
-  refreshLimit: 3
+  refreshLimit: 3,
+  refreshResetsCorrelator: false
 });
 ``` 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adjs",
-  "version": "2.0.0-beta.32",
+  "version": "2.0.0-beta.33",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adjs",
-  "version": "2.0.0-beta.32",
+  "version": "2.0.0-beta.33",
   "description": "Ad Library to simplify and optimize integration with ad networks such as DFP",
   "main": "./core.js",
   "types": "./types.d.ts",

--- a/src/Ad.ts
+++ b/src/Ad.ts
@@ -268,11 +268,11 @@ class Ad implements IAd {
   }
 
   @attachAsLifecycleMethod
-  public async refresh(): Promise<void> {
+  public async refresh(refreshCorrelator: boolean = false): Promise<void> {
     await this.page.setAsActive();
 
     if (typeof this.networkInstance.refresh !== 'undefined') {
-      await this.networkInstance.refresh();
+      await this.networkInstance.refresh(refreshCorrelator);
     } else {
       await this.networkInstance.destroy();
 

--- a/src/networks/DFP.ts
+++ b/src/networks/DFP.ts
@@ -93,7 +93,7 @@ class DfpAd implements INetworkInstance {
   }
 
   // TODO: Clean up event listeners
-  public refresh(): Promise<void> {
+  public refresh(resetCorrelator: boolean = false): Promise<void> {
     return new Promise(
       (resolve) => {
         if (!breakpointHandler(this.sizes, this.breakpoints).sizesSpecified) {
@@ -124,7 +124,7 @@ class DfpAd implements INetworkInstance {
             },
           );
 
-          googletag.pubads().refresh([slot], { changeCorrelator: false });
+          googletag.pubads().refresh([slot], { changeCorrelator: resetCorrelator });
 
           if (!slot.getContentUrl()) {
             this.ad.isEmpty = true;

--- a/src/plugins/AutoRefresh.ts
+++ b/src/plugins/AutoRefresh.ts
@@ -49,7 +49,7 @@ class AutoRefresh extends GenericPlugin {
       return;
     }
 
-    const { refreshRateInSeconds = 30, refreshLimit = null } = this.ad.configuration;
+    const { refreshRateInSeconds = 30, refreshLimit = null, refreshResetsCorrelator = false } = this.ad.configuration;
     dispatchEvent(
       this.ad.id,
       LOG_LEVELS.INFO,
@@ -78,7 +78,7 @@ class AutoRefresh extends GenericPlugin {
           `Ad viewability met. Refreshing Ad and resetting timer.`,
         );
 
-        await this.ad.refresh();
+        await this.ad.refresh(refreshResetsCorrelator);
 
         this.timeInView = 0;
         this.isRefreshing = false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,7 +44,7 @@ export interface IAd {
   slot: googletag.Slot;
 
   render(): Promise<void>;
-  refresh(): Promise<void>;
+  refresh(resetCorrelator?: boolean): Promise<void>;
   clear(): Promise<void>;
   destroy(): Promise<void>;
 
@@ -111,7 +111,7 @@ export interface INetworkArguments {
 
 export interface INetworkInstance {
   render: () => Promise<void>;
-  refresh?: () => Promise<void>;
+  refresh?: (resetCorrelator?: boolean) => Promise<void>;
   clear: () => Promise<void>;
   destroy: () => Promise<void>;
   [key: string]: any;
@@ -178,6 +178,7 @@ export interface IAdConfiguration {
   refreshOnBreakpoint?: boolean;
   refreshRateInSeconds?: number;
   refreshLimit?: number;
+  refreshResetsCorrelator?: boolean;
   sizes?: AdSizes;
   targeting?: IAdTargeting;
 }


### PR DESCRIPTION
## Description
We need the option to refresh the correlator when refreshing ads (this request came from MotorTrend). This PR fulfills that via the `AutoRefresh` plugin.

## PR Requirements
Before requesting review this criteria must be met: 
Overall test coverage >= current master?
- [ ] Yes
- [x] N.A. (I noticed we don't test against plugin options defined in `IAdConfiguration` - should we start testing these?)

Documentation included (if any behavioral changes)?
- [x] Yes
- [ ] N.A.

Backwards compatibility (if breaking change)?
- [x] Yes
- [ ] N.A.

## Release
Will this pr trigger a release i.e. `version` in `package.json` has been bumped?
- [x] Yes
- [ ] No

## Screenshots
If U.I. component, include screenshots or video screen capture showing
behavior and responsive styling below.
